### PR TITLE
[PHP] isset은 '변수가 존재하는지 검증'이 반드시 필요한 경우에만 사용

### DIFF
--- a/PHP/README.md
+++ b/PHP/README.md
@@ -36,8 +36,9 @@
 
 - 빈 값을 체크하는 경우 `empty()` 함수 사용
   - 참고: `empty`, `isset`, `is_null` 함수의 [조건표](https://www.virendrachandak.com/techtalk/php-isset-vs-empty-vs-is_null/)
-- 해당 변수가 set되었는지 확인하는 경우 `isset()` 함수 사용
+- `isset()` 함수는 변수가 존재하는지 확인할 때만 사용
   - 주로 `$arr['data']` 나 `$obj->data`가 존재하는지 체크할 때 `isset($arr['data'])` / `isset($obj->data)` 사용
+  - 'Not null'의 판단만 필요한 상황에서는 사용 금지
 - `compact()` / `extract()` 사용금지
   - 선언되지 않은 변수를 참조할 경우 어떤 오류도 발생하지 않음
   - 변수를 암묵적으로 참조하므로 유지보수가 어려움


### PR DESCRIPTION
PHP의 `isset`이 '`변수가 존재` AND `not null`'인 상황에서
단지 `not null`을 검사하기 위해서 `isset`을 사용하는 것은 어색하다고 생각합니다.

1. `변수가 존재`
2. `변수가 존재하며 not null`

위 두 가지 상황에서만 `isset`의 사용을 허용하면 좋겠습니다.