### PR TITLE
기울임 타입으로 인식된 '_' 기호 수정

### DIFF
--- a/Android/README.md
+++ b/Android/README.md
@@ -38,7 +38,7 @@ Kotlin 공식 문서의 [Coding Convention](http://kotlinlang.org/docs/reference
   - 예) reader_typo_setting_column_width.xml, simple_noti_icon_error.png
   - 아이콘(icon), 버튼(btn), 배경(bg), 셀렉터(sel)등 리소스의 종류를 상, 하위 개념 다음에 함께 표기한다. 
     상, 하위 개념과 리소스의 종류를 표기 한 뒤 기능과 모양에 어울리는 이름을 자유롭게 추가한다.
-  - 예) reader_tts_ **icon** _pre.png / main_purchased_ **btn** _book_read.png
+  - 예) reader_tts_**icon**\_pre.png / main_purchased_**btn**\_book_read.png
   - 리소스 상위, 하위개념의 영어 명칭은 안드로이드에 현재 개발된 상태를 참고하여 표기한다.
   - 예) 내 서재(library), 개별 책장(shelf), 구매목록(purchased), 서점(store), 설정(settings), 
   - 책장 목록(shelf_list), 최근 읽은 책(recent_book), 독서노트(reading_note), 보기 설정(typo_setting), 뷰어 설정(reader_setting)


### PR DESCRIPTION
## 개요
snake로 네이밍을 표현하는 예시에서 `_` 기호가 마크다운 문법 기울임(italic)으로 인식되어
의도와는 다른 내용이 표시되고 있습니다.

## 작업내용
- escape character `\`를 추가하였습니다.
- 공백을 제거하였습니다.

### 변경전
<img width="520" alt="2018-10-01 3 39 01" src="https://user-images.githubusercontent.com/5474864/46273365-2fa36500-c590-11e8-961d-d8ac71ad8853.png">

### 변경후
<img width="510" alt="2018-10-01 3 40 07" src="https://user-images.githubusercontent.com/5474864/46273398-4ea1f700-c590-11e8-9b18-cf5f4b53a2d3.png">
