### PR TITLE
[Android] TextView style에 대한 설정 설명 추가

### DIFF
--- a/Android/README.md
+++ b/Android/README.md
@@ -87,5 +87,5 @@ Kotlin 공식 문서의 [Coding Convention](http://kotlinlang.org/docs/reference
     ```
 
 ## TextView 설정
-- 2줄이상의 텍스트가 들어갈 경우 `lineSpacingMultiplier`를 `1.15`로 설정한다.
 - 디자인 가이드 상에 Medium으로 표현된 폰트일 경우 `bold` 속성을 적용한다.
+- 텍스트와 관련된 기타 설정은 [RIDI Design System](https://ridi.github.io/design-system/app/typography/) 을 따른다.

--- a/Android/README.md
+++ b/Android/README.md
@@ -88,4 +88,4 @@ Kotlin 공식 문서의 [Coding Convention](http://kotlinlang.org/docs/reference
 
 ## TextView 설정
 - 2줄이상의 텍스트가 들어갈 경우 `lineSpacingMultiplier`를 `1.15`로 설정한다.
-- `NotoSansCJKkr-Medium` 폰트일경우 `bold` 속성을 적용한다.
+- `디자인 가이드 상에 Medium으로 표현된 폰트일 경우` 폰트일경우 `bold` 속성을 적용한다.

--- a/Android/README.md
+++ b/Android/README.md
@@ -85,3 +85,7 @@ Kotlin 공식 문서의 [Coding Convention](http://kotlinlang.org/docs/reference
     CheckBox syncButton = (CheckBox) findViewById(R.id.sync_button);
     RadioButton koreanDicButton = (RadioButton) findViewById(R.id.korean_dic_button);
     ```
+
+## TextView 설정
+- 2줄이상의 텍스트가 들어갈 경우 `lineSpacingMultiplier`를 `1.15`로 설정한다.
+- `NotoSansCJKkr-Medium` 폰트일경우 `bold` 속성을 적용한다.

--- a/Android/README.md
+++ b/Android/README.md
@@ -88,4 +88,4 @@ Kotlin 공식 문서의 [Coding Convention](http://kotlinlang.org/docs/reference
 
 ## TextView 설정
 - 2줄이상의 텍스트가 들어갈 경우 `lineSpacingMultiplier`를 `1.15`로 설정한다.
-- `디자인 가이드 상에 Medium으로 표현된 폰트일 경우` 폰트일경우 `bold` 속성을 적용한다.
+- 디자인 가이드 상에 Medium으로 표현된 폰트일 경우 `bold` 속성을 적용한다.


### PR DESCRIPTION
## 개요
- 정해진 규칙이지만 문서화되지 않았던 TextView의 style에 대한 설정을 추가하였습니다.

## 작업내용
- `lineSpacingMultiplier` 설명 추가 ([지혜님의 설명](https://app.asana.com/0/0/900471738658501/f))
- 폰트 굵기에 대한 설명 추가 ([지혜님의 설명](https://app.asana.com/0/0/900471738658505/f))

## 기타
- 참고내역 : [지혜님 블로그](http://jihyeleee.com/blog/android-sundry-info/)