### PR TITLE
[iOS] Update style guide

### DIFF
--- a/iOS/.swiftlint.yml
+++ b/iOS/.swiftlint.yml
@@ -47,7 +47,6 @@ opt_in_rules:
   - multiline_literal_brackets # Multiline literals should have their surrounding brackets in a new line.
   - prohibited_super_call # Some methods should not call super.
   - redundant_type_annotation # Variables should not have redundant type annotation
-  - sorted_imports # Imports should be sorted.
   - toggle_bool # Prefer `someBool.toggle()` over `someBool = !someBool`.
   - unneeded_parentheses_in_closure_argument # Parentheses are not needed when declaring closure arguments.
   - unused_import # All imported modules should be required to make the file compile.

--- a/iOS/.swiftlint.yml
+++ b/iOS/.swiftlint.yml
@@ -15,6 +15,7 @@ disabled_rules:
   - todo # TODOs and FIXMEs should be resolved.
   - trailing_whitespace # Lines should not have trailing whitespace.
   - unused_setter_value # Setter value is not used.
+  - multiple_closures_with_trailing_closure # Trailing closure syntax should not be used when passing more than one closure argument.
 
 opt_in_rules:
   - anyobject_protocol # Prefer using `AnyObject` over class for class-only protocols.

--- a/iOS/.swiftlint.yml
+++ b/iOS/.swiftlint.yml
@@ -22,7 +22,6 @@ opt_in_rules:
   - closure_end_indentation # Closure end should have the same indentation as the line that started it.
   - closure_spacing # Closure expressions should have a single space inside each brace.
   - collection_alignment # All elements in a collection literal should be vertically aligned
-  - conditional_returns_on_newline # Conditional statements should always return on the next line.
   - contains_over_filter_count # Prefer `contains` over comparing `filter(where:).count` to `0`.
   - contains_over_filter_is_empty # Prefer `contains` over using `filter(where:).isEmpty`
   - contains_over_first_not_nil # Prefer `contains` over `first(where:) != nil` and `firstIndex(where:) != nil`.
@@ -33,7 +32,6 @@ opt_in_rules:
   - empty_string # Prefer checking `isEmpty` over comparing string to an empty string literal.
   - empty_xctest_method # Empty `XCTest` method should be avoided.
   - explicit_init # Explicitly calling `.init()` should be avoided.
-  - extension_access_modifier # Prefer to use extension access modifiers.
   - fallthrough # Fallthrough should be avoided.
   - fatal_error_message # A `fatalError` call should have a message.
   - file_header # Header comments should be consistent with project patterns.
@@ -52,7 +50,6 @@ opt_in_rules:
   - sorted_imports # Imports should be sorted.
   - toggle_bool # Prefer `someBool.toggle()` over `someBool = !someBool`.
   - unneeded_parentheses_in_closure_argument # Parentheses are not needed when declaring closure arguments.
-  - unowned_variable_capture # Prefer capturing references as weak to avoid potential crashes.
   - unused_import # All imported modules should be required to make the file compile.
   - unused_private_declaration # Private declarations should be referenced in that file.
   - vertical_parameter_alignment_on_call # Function parameters should be aligned vertically if they're in multiple lines in a method call.
@@ -95,3 +92,7 @@ type_name:
 # Limit vertical whitespace to a single empty line.
 vertical_whitespace:
   max_empty_lines: 2
+
+# Forbid "Created by" line in file header
+file_header:
+  forbidden_pattern: \b(Created by)\b

--- a/iOS/.swiftlint.yml
+++ b/iOS/.swiftlint.yml
@@ -59,10 +59,6 @@ custom_rules:
     name: 'Trailing logical operator'
     message: 'Leading logical operator should move to trailing.'
     regex: '^[\s]*(\|\||&&)'
-  no_exclamation_not_operator:
-    name: 'No exclamation not operator'
-    message: 'Force use `.not()` method instead of an exclamation mark prefix operator(`!`) for logical not.'
-    regex: '(!(?:(?!DEBUG))\w+)'
 
 # Identifier names should only contain alphanumeric characters and start with a lowercase character or should only contain capital letters.
 # In an exception to the above, variable names may start with a capital letter when they are declared static and immutable. Variable names should not be too long or too short.

--- a/iOS/README.md
+++ b/iOS/README.md
@@ -4,16 +4,6 @@
 
 [Apple's Swift API Design Guidelines](https://swift.org/documentation/api-design-guidelines/)와 [Ray Wenderlich Swift Style Guide](https://github.com/raywenderlich/swift-style-guide)를 따르되 다음을 예외로 한다.
 
-- 표현식 내에서 `Boolean`을 부정할 때는 `!` 대신 `not()`을 사용한다.
-  - Swift 정식 문법은 아니고 아래 Extension을 추가해야 한다.
-    ```swift
-    extension Bool {
-        func not() -> Bool {
-            return !self
-        }
-    }
-    ```
-
 - 단순히 `Boolean` 값을 변경할 때는 [toggle()](https://developer.apple.com/documentation/swift/bool/2994863-toggle)을 사용한다.
 
 - `if`, `guard` 문에 콤마(,)를 이용해 조건을 추가할 경우 콤마 뒤에서 다음 줄로 넘어간다.


### PR DESCRIPTION
# Changes
- Remove `conditional_returns_on_newline` rule from swiftlint
- Remove `extension_access_modifier` rule from swiftlint
- Remove `unowned_variable_capture` rule from swiftlint
- Remove `sorted_imports` rule from swiftlint
- Remove `multiple_closures_with_trailing_closure` rule from swiftlint
- Remove `no_exclamation_not_operator` rule from swiftlint, README.md
- Update `file_header` rule options for forbid `Created by` line in file header

# Reasons
### Remove `conditional_returns_on_newline` rule from swiftlint
One line returns can be good strategy for coding

> > conditional_returns_on_newline 의 경우 guard로 방어하는 경우 1줄로 return 치워버리는 것도 나쁘지 않은 전략이라고 생각합니다만, 이게 있는 사연이.... 있을까요?

> 특별한 사연은 없던 것으로 기억합니다 🤔
> 저도 근래 들어 Electron 작업하면서 많이 접하다 보니 1줄로 정리하는 것이 괜찮은 전략이라 생각합니다.

### Remove `extension_access_modifier` rule from swiftlint
Swift prevent using access modifier on Protocol Conformances which can be not consistent with normal extension access modifier if forces using access modifier on extension domain

> 이 케이스는 swiftformat 없이 모듈을 분리해 쓰는 경우 흔히 볼 수 있는데다 @sinoru 님이 말씀하신대로 유의미하지 않기 때문에 제거하는게 좋겠습니다

### Remove `unowned_variable_capture` rule from swiftlint
`unowned` and `weak` are pretty different which should be used separated. Not forces to use `weak`

https://www.uraimo.com/2016/10/27/unowned-or-weak-lifetime-and-performance/
https://mjtsai.com/blog/2015/11/24/how-swift-implements-unowned-and-weak-references/

> unowned_variable_capture 룰을 추가할 당시에는 예기치 못한 오류를 피하기 위해 방어적으로 코딩하는 것이 최선이라 생각했었습니다.
> 
> unowned의 이점인 속도를 체감할 상황도 마땅치가 않아서 굳이 예기치 않은 오류 상황을 만들어 가며 써야할까 라는 생각도 했었구요.
> 
> 그런데, 링크주신 글을 읽고 돌이켜 보니 시점을 관리 하기가 번거로워 편한쪽을 택하게 되버린것 같네요.
> 실제로도 최근에 스트리밍 뷰어를 작업하면서 weak로 인해 시점을 파악하기가 어려웠던 경험이 있어 더 뼈저리게 와닿습니다 😥
> 
> 그런 맥락으로 좀 더 코드의 의도와 시점을 명확하게 하기 위해 unowned_variable_capture 룰도 이번 기회에 제거하면 좋겠습니다.

### Remove `sorted_imports` rule from swiftlint
This rule does not that meaningful.

> 아... 이것도 약긴 기호의 문제라 판단해서.. 너무 꼼꼼하지 않나 싶어서요.
> module import 순서에 관한 Lint 입니다.
> 
> 저의 경우 시스템 모듈부터 나열 후, 그 후 커스텀 모듈을 나열.. 이런식으로 하고 있어서요.

> 아... 말씀하신 방식에선 이 룰이 상당히 번거롭게 느겨지네요 😥
> 
> Ridibooks 프로젝트에선 import 순서와 그룹핑에 의미를 부여하며 쓰기엔 ObjC가 혼재되어 있는 상태라 별 다른 고민 없이 알파벳 순을 사용하게 됐었는데요.
> 
> Swift 비중이 커져가고 있고 특별한 의미를 바탕으로 추가한 룰은 아니라서 이 룰은 제거하고, 말씀하신 방식을 가이드화하거나 순서는 각자 알아서 하는 것으로 해보면 좋겠습니다.
> 
> @genkino 님 생각은 어떠신가요?

> import된 항목들이 뭐가 있는지 확인하는 일이 그리 많지 않지만 어떤 것들이 import되어 있는지 확인할 때는 아무래도 어떤 식이든 정렬되어 있는 것이 약간이나마 쉽게 눈에 들어오는 점이 있다고 생각이 듭니다.
> 
> 그런데 젯브레인 계열의 IDE를 보면 이러한 식의 import 같은 경우 기본으로 아예 이러한 코드 영역을 숨겨보여주는데 코드 읽는데는 큰 문제가 없더라구요.
> 
> 그런 이유로 저도 순서는 알아서 하는 것으로 해도 좋을 거 같습니다.

### Remove `multiple_closures_with_trailing_closure` rule from swiftlint
This rule is conflicted with SwiftUI convention. And most cases's last closure input var is completion closure which can be implicit.

> 프로젝트 내에 한 method 호출에 여러개의 closure 입력이 있는 케이스들을 좀 찾아보면 좋지 않을까 싶긴 한데,
> 기본적으로 마지막은 그래도 completion, 내지는 위의 SwiftUI와 같이 View DSL 정도라서 convention 상으로 강제할 필요는 없지 않나 싶습니다..
> 
> 아쉽지만, 본인이 만약 혼동의 여지가 보인다면 그때 직접 explicit 하게 적는게 좋지 않을까 싶습니다.
### Remove `no_exclamation_not_operator` rule from swiftlint, README.md
This rule does not fit to general use cases.

### Update `file_header` rule options for forbid `Created by` line in file header
`file_header`'s default config only forbid "Copyright" on file header which is not intend to forbid.
So change "Copyright" to "Created by" to catch.
