### PR TITLE
긴 조건문 규칙 제거

### DIFF
--- a/PHP/README.md
+++ b/PHP/README.md
@@ -61,17 +61,6 @@
 - 삼항 연산자 사용
   - 연산자가 포함된 경우에는 반드시 괄호를 사용
     - `next_page = ($end_page === $total_pages) ? $end_page : ($end_page + 1);`
-- 긴 조건문
-  - `&&`, `||` 등은 가장 앞에 위치시킬 것
-  - 조건문이 여러줄일 경우 닫는 괄호와 brace는 새로운 줄에 위치시킬 것
-    ```php
-    if (someCondition1 !== null
-        && someCondition2 !== null
-        && someCondition3 !== null
-    ) {
-        /* ... */
-    }
-    ```
 
 #### 에러 제어 연산자
 - [Error Control Operator(`@`)](http://php.net/manual/en/language.operators.errorcontrol.php) 사용 금지


### PR DESCRIPTION
## 제안
PSR-12 에 관련 규칙이 정의 되어 있어 다음과 같이 제안합니다.
- PSR-12 은 조건문이 여러줄일 경우 `if (` 에서 한줄 내리도록 되어 있는데,
  이 규칙을 그대로 유지하는게 좋을 것으로 생각해서 제안드립니다.
- https://psr.kkame.net/accepted/psr-12-extended-coding-style-guide#5-1-if-elseif-else

### PSR-12 규칙
```php
if (
    someCondition1 !== null
    && someCondition2 !== null
    && someCondition3 !== null
) {
    /* ... */
}
```

### 기존 규칙
```php
if (someCondition1 !== null
    && someCondition2 !== null
    && someCondition3 !== null
) {
    /* ... */
}
```