### PR TITLE
(MariaDB) Charset과 Collection의 타입 내 utf8 제거 (utf8mb4를 사용하도록 가이드 수정) 

### DIFF
--- a/MariaDB(MySQL).md
+++ b/MariaDB(MySQL).md
@@ -88,7 +88,7 @@ AWS RDS에서 MariaDB 슬레이브를 구축할 경우 10.1 버전 권장[\*]
   - 참고: http://dev.mysql.com/doc/refman/5.5/en/date-and-time-types.html
 
     `MySQL permits you to store dates where the day or month and day are zero in a DATE or DATETIME column. This is useful for applications that need to store birthdates for which you may not know the exact date. In this case, you simply store the date as '2009-00-00' or '2009-01-00'. If you store dates such as these, you should not expect to get correct results for functions such as DATE_SUB() or DATE_ADD() that require complete dates. To disallow zero month or day parts in dates, enable the NO_ZERO_IN_DATE SQL mode.`
-  - `VARCHAR(6)`을 사용할 경우 3byte(utf8) * 6 + 1byte(length) = 19byte 가 사용되나, `DATE`는 3byte만 사용.
+  - `VARCHAR(6)`을 사용할 경우 4byte(utf8mb4) * 6 + 1byte(length) = 24byte 가 사용되나, `DATE`는 4byte만 사용.
   - zero date는 사용하지 않음(from '2015-01-00' to '2015-01-01')
     - 날짜 라이브러리마다 zero date 를 처리하는 방법이 달라서 오류가능성 높음
 

--- a/MariaDB(MySQL).md
+++ b/MariaDB(MySQL).md
@@ -18,8 +18,8 @@ AWS RDS에서 MariaDB 슬레이브를 구축할 경우 10.1 버전 권장[\*]
 - InnoDB(Compact) 사용
 - MyISAM 사용 금지 (트랜잭션이 없더라도 InnoDB가 유리함)
 - TokuDB 사용은 로그성 테이블에만 한정
-- Charset: `utf8` 혹은 `utf8mb4`
-- Collation: `utf8_unicode_ci` 혹은 `utf8mb4_unicode_ci`
+- Charset: `utf8mb4`
+- Collation: `utf8mb4_unicode_ci`
 
 #### 코멘트 작성
 - 테이블 코멘트는 반드시 작성
@@ -87,7 +87,7 @@ AWS RDS에서 MariaDB 슬레이브를 구축할 경우 10.1 버전 권장[\*]
 
   - 참고: http://dev.mysql.com/doc/refman/5.5/en/date-and-time-types.html
 
-    `MySQL permits you to store dates where the day or month and day are zero in a DATE or DATETIME column. This is useful for applications that need to store birthdates for which you may not know the exact date. In this case, you simply store the date as '2009-00-00' or '2009-01-00'. If you store dates such as these, you should not expect to get correct results for functions such as DATE_SUB() or DATE_ADD() that require complete dates. To disallow zero month or day parts in dates, enable the NO_ZERO_IN_DATE SQL mode.`  
+    `MySQL permits you to store dates where the day or month and day are zero in a DATE or DATETIME column. This is useful for applications that need to store birthdates for which you may not know the exact date. In this case, you simply store the date as '2009-00-00' or '2009-01-00'. If you store dates such as these, you should not expect to get correct results for functions such as DATE_SUB() or DATE_ADD() that require complete dates. To disallow zero month or day parts in dates, enable the NO_ZERO_IN_DATE SQL mode.`
   - `VARCHAR(6)`을 사용할 경우 3byte(utf8) * 6 + 1byte(length) = 19byte 가 사용되나, `DATE`는 3byte만 사용.
   - zero date는 사용하지 않음(from '2015-01-00' to '2015-01-01')
     - 날짜 라이브러리마다 zero date 를 처리하는 방법이 달라서 오류가능성 높음

--- a/MariaDB(MySQL).md
+++ b/MariaDB(MySQL).md
@@ -88,7 +88,7 @@ AWS RDS에서 MariaDB 슬레이브를 구축할 경우 10.1 버전 권장[\*]
   - 참고: http://dev.mysql.com/doc/refman/5.5/en/date-and-time-types.html
 
     `MySQL permits you to store dates where the day or month and day are zero in a DATE or DATETIME column. This is useful for applications that need to store birthdates for which you may not know the exact date. In this case, you simply store the date as '2009-00-00' or '2009-01-00'. If you store dates such as these, you should not expect to get correct results for functions such as DATE_SUB() or DATE_ADD() that require complete dates. To disallow zero month or day parts in dates, enable the NO_ZERO_IN_DATE SQL mode.`
-  - `VARCHAR(6)`을 사용할 경우 4byte(utf8mb4) * 6 + 1byte(length) = 24byte 가 사용되나, `DATE`는 4byte만 사용.
+  - `VARCHAR(6)`을 사용할 경우 4byte(utf8mb4) * 6 + 1byte(length) = 25byte 가 사용되나, `DATE`는 4byte만 사용.
   - zero date는 사용하지 않음(from '2015-01-00' to '2015-01-01')
     - 날짜 라이브러리마다 zero date 를 처리하는 방법이 달라서 오류가능성 높음
 


### PR DESCRIPTION
# 개요 
차기 mysql 버전에서 ut8의 참조 값인 utf8mb3 가 deprecated되고 utf8mb4으로 변경된다고 합니다.  https://dev.mysql.com/doc/refman/8.0/en/charset-unicode-utf8mb3.html

이에 utf8 이 deprecated 되는 것을 고려하여 스타일가이드에 utf8 을 제거하고 utf8mb4 만 권장하도록 가이드하면 좋을 것 같습니다.

# 변경사항 
- charset과 collection 에서 utf8 가이드 제거.
- utf8 기준으로 설명된 byte를 utf8mb4 기준으로 변경
- 90행 문장 마지막에 포함되어있는 불필요한 공백 제거